### PR TITLE
Bugfix: new twitter accounts don't work - server 500 error

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 
 Visit the [Fork CMS knowledge base](http://fork-cms.com/knowledge-base) to learn how to install a module. To download the zip-package go to the [extension page](http://www.fork-cms.com/extensions/detail/twitter) of the module on fork-cms.com.
 
+## Updating
+
+Update from 2.0.0 to 2.1.0? Just apply this SQL update to your database and your done.
+
+```
+ALTER TABLE `twitter_users` CHANGE `twitter_id` `twitter_id` BIGINT(20) UNSIGNED NULL DEFAULT NULL;
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 Visit the [Fork CMS knowledge base](http://fork-cms.com/knowledge-base) to learn how to install a module. To download the zip-package go to the [extension page](http://www.fork-cms.com/extensions/detail/twitter) of the module on fork-cms.com.
 
+## Versions
+
+- 2.1.0 bugfix for "Sorry, that page does not exist" error.
+- 2.0.0 is compatible with forkcms 3.7.x (and higher)
+
 ## Updating
 
 Update from 2.0.0 to 2.1.0? Just apply this SQL update to your database and your done.

--- a/src/Backend/Modules/Twitter/Installer/Data/install.sql
+++ b/src/Backend/Modules/Twitter/Installer/Data/install.sql
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS `twitter_tweets` (
 
 CREATE TABLE IF NOT EXISTS `twitter_users` (
  `id` int(11) NOT NULL AUTO_INCREMENT,
- `twitter_id` int(11) DEFAULT NULL,
+ `twitter_id` bigint(20) unsigned DEFAULT NULL,
  `username` varchar(50) NOT NULL,
  `name` varchar(255) DEFAULT NULL,
  `location` varchar(255) DEFAULT NULL,

--- a/src/Backend/Modules/Twitter/info.xml
+++ b/src/Backend/Modules/Twitter/info.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module>
     <name>twitter</name>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <requirements>
         <minimum_version>3.7.0</minimum_version>
     </requirements>


### PR DESCRIPTION
Bugfix: when using new (created recently) twitter accounts, you could receive the following error: Error 404 - this page does not exists (or you will get a server 500 error in production where debug is off).

This is caused by using a to small storage field (int) for twitter_users.twitter_id, changed the field to a bigint.
